### PR TITLE
[wip] Update to support latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Acmex.OpenSSL.generate_key(:rsa, "/path/account.key")
 And now start the client with the generated key file:
 
 ```elixir
-Acmex.start_link("/path/account.key")
+Acmex.start_link(keyfile: "/path/account.key")
+# or with a plaintext key loaded from ENV or other...
+Acmex.start_link(key: "/path/account.key")
 ```
 
 ### Account

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Acmex.get_certificate(order)
 To run the tests you need an `ACME Test Server`. You can use [Pebble](https://github.com/letsencrypt/pebble):
 
 ```bash
-$ docker -d run -e "PEBBLE_VA_NOSLEEP=1" -e "PEBBLE_VA_ALWAYS_VALID=1" -e "PEBBLE_WFE_NONCEREJECT=0" -p 14000:14000 letsencrypt/pebble:2018-09-28
+$ docker run -e "PEBBLE_VA_NOSLEEP=1" -e "PEBBLE_VA_ALWAYS_VALID=1" -e "PEBBLE_WFE_NONCEREJECT=0" -p 14000:14000 letsencrypt/pebble:2.0.2
 $ mix test
 ```
 

--- a/lib/acmex.ex
+++ b/lib/acmex.ex
@@ -21,20 +21,23 @@ defmodule Acmex do
   ## Parameters
 
     - keyfile: The path to an RSA key.
+    - key: RSA key plaintext.
     - name: Optional name for the Client.
 
   ## Examples
 
-      iex> Acmex.start_link("test/support/fixture/account.key")
+      iex> Acmex.start_link(keyfile: "test/support/fixture/account.key")
       {:ok, #PID<...>}
 
-      iex> Acmex.start_link("test/support/fixture/account.key", :acmex_optional_name)
+      iex> Acmex.start_link(keyfile: "test/support/fixture/account.key", name: :acmex_optional_name)
       {:ok, #PID<...>}
 
   """
-  @spec start_link(binary(), atom()) :: on_start_link()
-  def start_link(keyfile, name \\ Client),
-    do: GenServer.start_link(Client, [keyfile: keyfile], name: name)
+  @spec start_link(keyword()) :: on_start_link()
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, Client)
+    GenServer.start_link(Client, opts, name: name)
+  end
 
   @doc """
   Creates a new account.

--- a/lib/acmex.ex
+++ b/lib/acmex.ex
@@ -183,4 +183,23 @@ defmodule Acmex do
   """
   @spec get_certificate(Order.t()) :: certificate_reply()
   def get_certificate(order), do: GenServer.call(Client, {:get_certificate, order})
+
+  @doc """
+  Revoke the certificate.
+
+  The format of the certificate is application/pem-certificate-chain.
+
+  ## Parameters
+
+    - certificate: The certificate to be revoked in DER format (end-entity cert, not the chain).
+    - reason: Optional reason enum.
+
+  ## Examples
+
+      iex> Acmex.revoke_certificate("MIIEDTCCAvegAwIBAgIRAP8...")
+      :ok
+
+  """
+  @spec revoke_certificate(binary(), integer()) :: certificate_reply()
+  def revoke_certificate(certificate, reason \\ 0), do: GenServer.call(Client, {:revoke_certificate, certificate, reason})
 end

--- a/lib/acmex/client.ex
+++ b/lib/acmex/client.ex
@@ -147,7 +147,7 @@ defmodule Acmex.Client do
       reason: reason
     }
 
-    with {:ok, resp} <-
+    with {:ok, _resp} <-
            account_signed_post(
              state.directory.revoke_cert,
              payload,

--- a/lib/acmex/crypto.ex
+++ b/lib/acmex/crypto.ex
@@ -3,10 +3,24 @@ defmodule Acmex.Crypto do
 
   alias JOSE.{JWK, JWS}
 
-  def get_jwk(keyfile) do
-    keyfile
-    |> JWK.from_pem_file()
-    |> JWK.to_map()
+  def fetch_jwk_from_file(keyfile) do
+    try do
+      {:ok,
+       keyfile
+       |> JWK.from_pem_file()
+       |> JWK.to_map()}
+    rescue
+      _ -> {:error, :invalid_jwk}
+    end
+  end
+
+  def fetch_jwk(pem) do
+    try do
+      {%{kty: _}, jwk} = pem |> JOSE.JWK.from_pem() |> JOSE.JWK.to_map()
+      {:ok, jwk}
+    rescue
+      _ -> {:error, :invalid_jwk}
+    end
   end
 
   def sign(jwk, payload, %{"kid" => _kid} = header) do

--- a/lib/acmex/openssl.ex
+++ b/lib/acmex/openssl.ex
@@ -45,6 +45,7 @@ defmodule Acmex.OpenSSL do
 
     - key_path: Private key path.
     - subject: Subject attributes.
+    - config_path: Path to an OpenSSL config file. Notably used to configure `subjectAltName` in broader versions of openssl.
 
   ## Examples
 
@@ -53,9 +54,13 @@ defmodule Acmex.OpenSSL do
       {:ok, <<48, 130, 2, 91, 48, 1, ...>>}
 
   """
-  @spec generate_csr(binary(), Map.t()) :: {:ok, bitstring()} | {:error, binary()}
-  def generate_csr(key_path, subject) do
-    openssl(~w(req -new -nodes -key #{key_path} -subj #{format_subject(subject)} -outform DER))
+  @spec generate_csr(binary(), Map.t(), binary()) :: {:ok, bitstring()} | {:error, binary()}
+  def generate_csr(key_path, subject, config_path \\ nil) do
+    openssl(
+      ~w(req -new -nodes -key #{key_path} -subj #{format_subject(subject)} #{
+        format_config_path(config_path)
+      } -outform DER)
+    )
   end
 
   defp openssl(args) do
@@ -70,4 +75,7 @@ defmodule Acmex.OpenSSL do
     |> Enum.map(fn {k, v} -> "/#{@subject_keys[k]}=#{v}" end)
     |> Enum.join()
   end
+
+  def format_config_path(nil), do: ""
+  def format_config_path(config_path), do: "-config #{config_path}"
 end

--- a/lib/acmex/request.ex
+++ b/lib/acmex/request.ex
@@ -21,7 +21,7 @@ defmodule Acmex.Request do
     end
     jws = Crypto.sign(jwk, encoded_payload, jws_headers(url, nonce, kid))
 
-    resp = HTTPoison.post(url, Jason.encode!(jws), @default_headers, hackney: hackney_opts())
+    resp = HTTPoison.post(url, Jason.encode!(jws), @default_headers ++ (headers || []), hackney: hackney_opts())
 
     if handler, do: handle_response(resp, handler), else: handle_response(resp)
   end
@@ -30,7 +30,7 @@ defmodule Acmex.Request do
     jws = Crypto.sign(jwk, "", jws_headers(url, nonce, kid))
 
     resp =
-      HTTPoison.post(url, Jason.encode!(jws), @default_headers ++ headers, hackney: hackney_opts())
+      HTTPoison.post(url, Jason.encode!(jws), @default_headers ++ (headers || []), hackney: hackney_opts())
 
     if handler, do: handle_response(resp, handler), else: handle_response(resp)
   end

--- a/lib/acmex/resource/challenge.ex
+++ b/lib/acmex/resource/challenge.ex
@@ -3,7 +3,6 @@ defmodule Acmex.Resource.Challenge do
   This structure represents a challenge to prove control of an identifier.
   """
 
-  alias Acmex.Request
   alias JOSE.JWK
 
   defstruct [
@@ -14,13 +13,6 @@ defmodule Acmex.Resource.Challenge do
   ]
 
   def new(challenge), do: struct(__MODULE__, challenge)
-
-  def reload(%__MODULE__{url: url}) do
-    case Request.get(url) do
-      {:ok, resp} -> {:ok, __MODULE__.new(resp.body)}
-      error -> error
-    end
-  end
 
   def get_response(%__MODULE__{type: "http-01"} = challenge, jwk),
     do: get_key_authorization(challenge, jwk)

--- a/lib/acmex/resource/order.ex
+++ b/lib/acmex/resource/order.ex
@@ -4,7 +4,6 @@ defmodule Acmex.Resource.Order do
   """
 
   alias Acmex.Request
-  alias Acmex.Resource.Authorization
 
   defstruct [
     :authorizations,
@@ -16,9 +15,7 @@ defmodule Acmex.Resource.Order do
     :url
   ]
 
-  def new(%{authorizations: authorizations} = order, headers \\ []) do
-    order = %{order | authorizations: Enum.map(authorizations, &new_authorization(&1))}
-
+  def new(order, headers \\ []) do
     url =
       case Request.get_header(headers, "Location") do
         nil -> order[:url]
@@ -26,19 +23,5 @@ defmodule Acmex.Resource.Order do
       end
 
     struct(__MODULE__, Map.put(order, :url, url))
-  end
-
-  def reload(%__MODULE__{url: url}) do
-    case Request.get(url) do
-      {:ok, resp} -> {:ok, __MODULE__.new(Map.put(resp.body, :url, url))}
-      error -> error
-    end
-  end
-
-  defp new_authorization(url), do: Authorization.new(fetch_authorization(url))
-
-  defp fetch_authorization(url) do
-    {:ok, resp} = Request.get(url)
-    resp.body
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,8 +43,8 @@ defmodule Acmex.MixProject do
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
       {:httpoison, "~> 1.0"},
-      {:jose, "~> 1.8"},
-      {:poison, "~> 3.1"}
+      {:jose, "~> 1.9"},
+      {:jason, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -13,7 +13,7 @@
   "httpoison": {:hex, :httpoison, "1.2.0", "2702ed3da5fd7a8130fc34b11965c8cfa21ade2f232c00b42d96d4967c39a3a3", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.2", "e21cb58a09f0228a9e0b95eaa1217f1bcfc31a1aaa6e1fdf2f53a33f7dbd9494", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
+  "jose": {:hex, :jose, "1.9.0", "4167c5f6d06ffaebffd15cdb8da61a108445ef5e85ab8f5a7ad926fdf3ada154", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
@@ -24,5 +24,5 @@
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}
 }

--- a/test/acmex/crypto_test.exs
+++ b/test/acmex/crypto_test.exs
@@ -5,16 +5,17 @@ defmodule Acmex.CryptoTest do
   alias JOSE.JWK
   alias JOSE.JWS
 
-  describe "Crypto.get_jwk/1" do
+  describe "Crypto.fetch_jwk/1" do
     test "returns jwk" do
-      jwk = Crypto.get_jwk("test/support/fixture/account.key")
+      {:ok, jwk} = Crypto.fetch_jwk_from_file("test/support/fixture/account.key")
       assert JWK.thumbprint(jwk) == "5zmJUVWaucybUNJSLeCaO9D_cauS5QiwA92KTiY_vNc"
     end
   end
 
   describe "Crypto.sign/3" do
     setup do
-      [jwk: Crypto.get_jwk("test/support/fixture/account.key")]
+      {:ok, jwk} = Crypto.fetch_jwk_from_file("test/support/fixture/account.key")
+      [jwk: jwk]
     end
 
     test "signs a payload with a header without kid", %{jwk: jwk} do

--- a/test/acmex/crypto_test.exs
+++ b/test/acmex/crypto_test.exs
@@ -26,8 +26,8 @@ defmodule Acmex.CryptoTest do
 
       body = %{termsOfServiceAgreed: true, contact: ["mailto:info@example.com"]}
 
-      jws = Crypto.sign(jwk, Poison.encode!(body), headers)
-      protected = Poison.decode!(JWS.peek_protected(jws))
+      jws = Crypto.sign(jwk, Jason.encode!(body), headers)
+      protected = Jason.decode!(JWS.peek_protected(jws))
 
       assert protected["alg"] == "RS256"
       assert protected["url"] == "https://localhost:14000/sign-me-up"
@@ -43,8 +43,8 @@ defmodule Acmex.CryptoTest do
 
       body = %{termsOfServiceAgreed: true, contact: ["mailto:info@example.com"]}
 
-      jws = Crypto.sign(jwk, Poison.encode!(body), headers)
-      protected = Poison.decode!(JWS.peek_protected(jws))
+      jws = Crypto.sign(jwk, Jason.encode!(body), headers)
+      protected = Jason.decode!(JWS.peek_protected(jws))
 
       assert protected["alg"] == "RS256"
       assert protected["url"] == "https://localhost:14000/sign-me-up"

--- a/test/acmex/request_test.exs
+++ b/test/acmex/request_test.exs
@@ -50,7 +50,7 @@ defmodule Acmex.RequestTest do
       {:ok, response} = Request.head(directory.new_nonce)
 
       assert response.body == ""
-      assert response.status_code == 204
+      assert response.status_code == 200
       assert Request.get_header(response.headers, "Replay-Nonce")
     end
   end

--- a/test/acmex/request_test.exs
+++ b/test/acmex/request_test.exs
@@ -29,7 +29,7 @@ defmodule Acmex.RequestTest do
     setup %{directory: directory} do
       {:ok, response} = Request.head(directory.new_nonce)
       nonce = Request.get_header(response.headers, "Replay-Nonce")
-      jwk = Crypto.get_jwk("test/support/fixture/account.key")
+      {:ok, jwk} = Crypto.fetch_jwk_from_file("test/support/fixture/account.key")
 
       [directory: directory, jwk: jwk, nonce: nonce]
     end

--- a/test/acmex/resource/challenge_test.exs
+++ b/test/acmex/resource/challenge_test.exs
@@ -27,21 +27,6 @@ defmodule Acmex.Resource.ChallengeTest do
     end
   end
 
-  describe "Challenge.reload/1" do
-    test "returns updated challenge", %{challenge: challenge} do
-      {:ok, challenge} = Challenge.reload(challenge)
-
-      assert challenge.status == "pending"
-    end
-
-    test "returns error because challenge url is invalid", %{challenge: challenge} do
-      directory_url = Application.get_env(:acmex, :directory_url)
-      challenge = %{challenge | url: "#{directory_url}/chalZ/mGxR5"}
-
-      assert {:error, _} = Challenge.reload(challenge)
-    end
-  end
-
   describe "Challenge.get_response/2" do
     test "returns challenge response", %{challenge: challenge} do
       {:ok, jwk} = Crypto.fetch_jwk_from_file("test/support/fixture/account.key")

--- a/test/acmex/resource/challenge_test.exs
+++ b/test/acmex/resource/challenge_test.exs
@@ -44,7 +44,7 @@ defmodule Acmex.Resource.ChallengeTest do
 
   describe "Challenge.get_response/2" do
     test "returns challenge response", %{challenge: challenge} do
-      jwk = Crypto.get_jwk("test/support/fixture/account.key")
+      {:ok, jwk} = Crypto.fetch_jwk_from_file("test/support/fixture/account.key")
 
       {:ok, response} = Challenge.get_response(challenge, jwk)
 
@@ -54,7 +54,7 @@ defmodule Acmex.Resource.ChallengeTest do
 
   describe "Challenge.get_key_authorization/2" do
     test "returns challenge key authorization", %{challenge: challenge} do
-      jwk = Crypto.get_jwk("test/support/fixture/account.key")
+      {:ok, jwk} = Crypto.fetch_jwk_from_file("test/support/fixture/account.key")
 
       {:ok, authorization} = Challenge.get_key_authorization(challenge, jwk)
 

--- a/test/acmex/resource/order_test.exs
+++ b/test/acmex/resource/order_test.exs
@@ -1,38 +1,9 @@
 defmodule Acmex.Resource.OrderTest do
   use ExUnit.Case, async: true
 
-  alias Acmex.Request
-  alias Acmex.Resource.Order
-
   setup_all do
     {:ok, order} = Acmex.new_order(["example.com"])
 
     [order: order]
-  end
-
-  describe "Order.new/2" do
-    test "returns order struct", %{order: order} do
-      {:ok, resp} = Request.get(order.url)
-
-      order = Order.new(resp.body, resp.headers)
-
-      assert order.__struct__ == Order
-      assert order.status == "pending"
-    end
-  end
-
-  describe "Order.reload/1" do
-    test "returns updated order", %{order: order} do
-      {:ok, order} = Order.reload(order)
-
-      assert order.status == "pending"
-    end
-
-    test "returns error because order url is invalid", %{order: order} do
-      directory_url = Application.get_env(:acmex, :directory_url)
-      order = %{order | url: "#{directory_url}/my-order/mGxR5"}
-
-      assert {:error, _} = Order.reload(order)
-    end
   end
 end

--- a/test/acmex_test.exs
+++ b/test/acmex_test.exs
@@ -1,10 +1,10 @@
 defmodule AcmexTest do
   use ExUnit.Case, async: true
 
-  alias Acmex.Resource.{Account, Authorization, Order}
+  alias Acmex.Resource.{Account, Authorization}
 
   defp poll_order_status(order) do
-    case Order.reload(order) do
+    case Acmex.get_order(order.url) do
       {:ok, %{status: "valid"} = order} -> order
       {:ok, order} -> poll_order_status(order)
     end

--- a/test/acmex_test.exs
+++ b/test/acmex_test.exs
@@ -12,14 +12,18 @@ defmodule AcmexTest do
 
   describe "Acmex.start_link/1" do
     test "returns ok" do
-      assert {:ok, _} = Acmex.start_link("test/support/fixture/account.key", :acmex_test)
+      assert {:ok, _} = Acmex.start_link(keyfile: "test/support/fixture/account.key", name: :acmex_test)
+    end
+
+    test "returns ok via :key" do
+      assert {:ok, _} = Acmex.start_link(key: File.read!("test/support/fixture/account.key"), name: :acmex_key_test)
     end
 
     test "returns error" do
       Process.flag(:trap_exit, true)
-      result = Acmex.start_link("test/support/fixture/account2.key", :acmex_test)
+      result = Acmex.start_link(keyfile: "test/support/fixture/account2.key", name: :acmex_test)
 
-      assert result == {:error, "keyfile test/support/fixture/account2.key does not exists"}
+      assert result == {:error, "supplied keyfile test/support/fixture/account2.key does not exists"}
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 ExUnit.start()
 
-Acmex.start_link("test/support/fixture/account.key")
+Acmex.start_link(keyfile: "test/support/fixture/account.key")
 Acmex.new_account(["mailto:info@example.com"], true)


### PR DESCRIPTION
- [x] Support [POST-as-GET changes](https://community.letsencrypt.org/t/acme-breaking-change-most-gets-become-posts/71025)
- [x] Support for specifying openssl config file to contain `subjectAltName` (required now vs common name)
- [x] Support specifying account key directly vs keyfile (if loaded via ENV)
- [x] Move to Jason