### PR TITLE
add timeout custom config to genserver calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add custom timeout param to functions which use `GenServer.call` in Acmex Module
+
 ## [0.1.2] - 2020-05-03
 ### Changed
 - Improve the documentation.

--- a/README.md
+++ b/README.md
@@ -60,29 +60,36 @@ children = [
 #### Creating a new account
 
 The second parameter is about the agreement of the terms of service.
+The third parameter is optional and represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
 
 ```elixir
-Acmex.new_account(["mailto:info@example.com"], true)
+Acmex.new_account(["mailto:info@example.com"], true, \\ 5_000)
 ```
 
 #### Fetch existing account
+It accepts an opttional parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
 
 ```elixir
-Acmex.get_account()
+Acmex.get_account( \\ 5_000)
 ```
 
 ### Order
 
 #### Creating a new order
 
+It accepts an optional second parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
+
 ```elixir
-Acmex.new_order(["example.com"])
+Acmex.new_order(["example.com"], \\ 5_000)
 ```
 
 #### Fetch an existing order
 
+It accepts an optional second parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
 ```elixir
-Acmex.get_order(order.url)
+Acmex.get_order(order.url, \\ 5_000)
 ```
 
 ### Challenge
@@ -96,43 +103,56 @@ challenge = Acmex.Resource.Authorization.http(authorization)
 
 #### Return a challenge response
 
+It accepts an optional second parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
 ```elixir
-Acmex.get_challenge_response(challenge)
+Acmex.get_challenge_response(challenge, \\ 5_000)
 ```
 
 #### Validate the challenge
 
+It accepts an optional second parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
 ```elixir
-{:ok, challenge} = Acmex.validate_challenge(challenge)
+{:ok, challenge} = Acmex.validate_challenge(challenge, \\ 5_000)
 ```
 
 #### Fetch an existing challenge
 
+It accepts an optional second parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
 ```elixir
-Acmex.get_challenge(challenge.url)
+Acmex.get_challenge(challenge.url, \\ 5_000)
 ```
 
 ### Certificate
 
 #### Finalize an order
 
+It accepts an optional third parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
+
 ```elixir
 order_key = Acmex.OpenSSL.generate_key(:rsa)
 {:ok, csr} = Acmex.OpenSSL.generate_csr(order_key, ["example.com"])
-{:ok, order} = Acmex.finalize_order(order, csr)
+{:ok, order} = Acmex.finalize_order(order, csr, \\ 5_000)
 ```
 
 #### Get the certificate
 
+It accepts an optional second parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
 ```elixir
-Acmex.get_certificate(order)
+Acmex.get_certificate(order, \\ 5_000)
 ```
 
 #### Revoke a certificate
 
+It accepts an optional third parameter which represents the function timeout, once it runs as an async process. The default value is "5_000" ms.
+
 ```elixir
 {:ok, certificate} = Acmex.get_certificate(order)
-Acmex.revoke_certificate(certificate, 0)
+Acmex.revoke_certificate(certificate, 0, \\ 5_000)
 ```
 
 ## Documentation

--- a/lib/acmex.ex
+++ b/lib/acmex.ex
@@ -133,7 +133,8 @@ defmodule Acmex do
 
   """
   @spec get_challenge(String.t()) :: challenge_reply()
-  def get_challenge(url, timeout \\ 5_000), do: GenServer.call(Client, {:get_challenge, url}, timeout)
+  def get_challenge(url, timeout \\ 5_000),
+    do: GenServer.call(Client, {:get_challenge, url}, timeout)
 
   @doc """
   Gets the challenge response.

--- a/lib/acmex.ex
+++ b/lib/acmex.ex
@@ -70,8 +70,8 @@ defmodule Acmex do
 
   """
   @spec new_account([String.t()], boolean()) :: account_reply()
-  def new_account(contact, tos),
-    do: GenServer.call(Client, {:new_account, contact, tos}, genserver_timeout())
+  def new_account(contact, tos, timeout \\ 5_000),
+    do: GenServer.call(Client, {:new_account, contact, tos}, timeout)
 
   @doc """
   Gets an existing account.
@@ -85,7 +85,7 @@ defmodule Acmex do
 
   """
   @spec get_account() :: account_reply()
-  def get_account, do: GenServer.call(Client, :get_account, genserver_timeout())
+  def get_account(timeout \\ 5_000), do: GenServer.call(Client, :get_account, timeout)
 
   @doc """
   Creates a new order.
@@ -100,8 +100,8 @@ defmodule Acmex do
 
   """
   @spec new_order([String.t()]) :: order_reply()
-  def new_order(identifiers),
-    do: GenServer.call(Client, {:new_order, identifiers}, genserver_timeout())
+  def new_order(identifiers, timeout \\ 5_000),
+    do: GenServer.call(Client, {:new_order, identifiers}, timeout)
 
   @doc """
   Gets an existing order.
@@ -117,7 +117,7 @@ defmodule Acmex do
 
   """
   @spec get_order(String.t()) :: order_reply()
-  def get_order(url), do: GenServer.call(Client, {:get_order, url}, genserver_timeout())
+  def get_order(url, timeout \\ 5_000), do: GenServer.call(Client, {:get_order, url}, timeout)
 
   @doc """
   Gets an existing challenge.
@@ -133,7 +133,7 @@ defmodule Acmex do
 
   """
   @spec get_challenge(String.t()) :: challenge_reply()
-  def get_challenge(url), do: GenServer.call(Client, {:get_challenge, url}, genserver_timeout())
+  def get_challenge(url, timeout \\ 5_000), do: GenServer.call(Client, {:get_challenge, url}, timeout)
 
   @doc """
   Gets the challenge response.
@@ -162,8 +162,8 @@ defmodule Acmex do
 
   """
   @spec get_challenge_response(Challenge.t()) :: {:ok, map()}
-  def get_challenge_response(challenge),
-    do: GenServer.call(Client, {:get_challenge_response, challenge}, genserver_timeout())
+  def get_challenge_response(challenge, timeout \\ 5_000),
+    do: GenServer.call(Client, {:get_challenge_response, challenge}, timeout)
 
   @doc """
   Validates the challenge.
@@ -179,8 +179,8 @@ defmodule Acmex do
 
   """
   @spec validate_challenge(Challenge.t()) :: challenge_reply()
-  def validate_challenge(challenge),
-    do: GenServer.call(Client, {:validate_challenge, challenge}, genserver_timeout())
+  def validate_challenge(challenge, timeout \\ 5_000),
+    do: GenServer.call(Client, {:validate_challenge, challenge}, timeout)
 
   @doc """
   Finalizes the order.
@@ -196,8 +196,8 @@ defmodule Acmex do
 
   """
   @spec finalize_order(Order.t(), String.t()) :: challenge_reply()
-  def finalize_order(order, csr),
-    do: GenServer.call(Client, {:finalize_order, order, csr}, genserver_timeout())
+  def finalize_order(order, csr, timeout \\ 5_000),
+    do: GenServer.call(Client, {:finalize_order, order, csr}, timeout)
 
   @doc """
   Gets the certificate.
@@ -215,8 +215,8 @@ defmodule Acmex do
 
   """
   @spec get_certificate(Order.t()) :: certificate_reply()
-  def get_certificate(order),
-    do: GenServer.call(Client, {:get_certificate, order}, genserver_timeout())
+  def get_certificate(order, timeout \\ 5_000),
+    do: GenServer.call(Client, {:get_certificate, order}, timeout)
 
   @doc """
   Revokes a certificate.
@@ -233,8 +233,8 @@ defmodule Acmex do
 
   """
   @spec revoke_certificate(String.t(), integer()) :: certificate_revocation_reply()
-  def revoke_certificate(certificate, reason_code \\ 0) do
-    GenServer.call(Client, {:revoke_certificate, certificate, reason_code}, genserver_timeout())
+  def revoke_certificate(certificate, reason_code \\ 0, timeout \\ 5_000) do
+    GenServer.call(Client, {:revoke_certificate, certificate, reason_code}, timeout)
   end
 
   @spec child_spec(list()) :: Supervisor.child_spec()
@@ -245,6 +245,4 @@ defmodule Acmex do
       start: {__MODULE__, :start_link, args}
     }
   end
-
-  defp genserver_timeout, do: Application.get_env(:acmex, :genserver_timeout, 5_000)
 end

--- a/lib/acmex.ex
+++ b/lib/acmex.ex
@@ -70,7 +70,8 @@ defmodule Acmex do
 
   """
   @spec new_account([String.t()], boolean()) :: account_reply()
-  def new_account(contact, tos), do: GenServer.call(Client, {:new_account, contact, tos})
+  def new_account(contact, tos),
+    do: GenServer.call(Client, {:new_account, contact, tos}, genserver_timeout())
 
   @doc """
   Gets an existing account.
@@ -84,7 +85,7 @@ defmodule Acmex do
 
   """
   @spec get_account() :: account_reply()
-  def get_account, do: GenServer.call(Client, :get_account)
+  def get_account, do: GenServer.call(Client, :get_account, genserver_timeout())
 
   @doc """
   Creates a new order.
@@ -99,7 +100,8 @@ defmodule Acmex do
 
   """
   @spec new_order([String.t()]) :: order_reply()
-  def new_order(identifiers), do: GenServer.call(Client, {:new_order, identifiers})
+  def new_order(identifiers),
+    do: GenServer.call(Client, {:new_order, identifiers}, genserver_timeout())
 
   @doc """
   Gets an existing order.
@@ -115,7 +117,7 @@ defmodule Acmex do
 
   """
   @spec get_order(String.t()) :: order_reply()
-  def get_order(url), do: GenServer.call(Client, {:get_order, url})
+  def get_order(url), do: GenServer.call(Client, {:get_order, url}, genserver_timeout())
 
   @doc """
   Gets an existing challenge.
@@ -131,7 +133,7 @@ defmodule Acmex do
 
   """
   @spec get_challenge(String.t()) :: challenge_reply()
-  def get_challenge(url), do: GenServer.call(Client, {:get_challenge, url})
+  def get_challenge(url), do: GenServer.call(Client, {:get_challenge, url}, genserver_timeout())
 
   @doc """
   Gets the challenge response.
@@ -161,7 +163,7 @@ defmodule Acmex do
   """
   @spec get_challenge_response(Challenge.t()) :: {:ok, map()}
   def get_challenge_response(challenge),
-    do: GenServer.call(Client, {:get_challenge_response, challenge})
+    do: GenServer.call(Client, {:get_challenge_response, challenge}, genserver_timeout())
 
   @doc """
   Validates the challenge.
@@ -177,7 +179,8 @@ defmodule Acmex do
 
   """
   @spec validate_challenge(Challenge.t()) :: challenge_reply()
-  def validate_challenge(challenge), do: GenServer.call(Client, {:validate_challenge, challenge})
+  def validate_challenge(challenge),
+    do: GenServer.call(Client, {:validate_challenge, challenge}, genserver_timeout())
 
   @doc """
   Finalizes the order.
@@ -193,7 +196,8 @@ defmodule Acmex do
 
   """
   @spec finalize_order(Order.t(), String.t()) :: challenge_reply()
-  def finalize_order(order, csr), do: GenServer.call(Client, {:finalize_order, order, csr})
+  def finalize_order(order, csr),
+    do: GenServer.call(Client, {:finalize_order, order, csr}, genserver_timeout())
 
   @doc """
   Gets the certificate.
@@ -211,7 +215,8 @@ defmodule Acmex do
 
   """
   @spec get_certificate(Order.t()) :: certificate_reply()
-  def get_certificate(order), do: GenServer.call(Client, {:get_certificate, order})
+  def get_certificate(order),
+    do: GenServer.call(Client, {:get_certificate, order}, genserver_timeout())
 
   @doc """
   Revokes a certificate.
@@ -229,7 +234,7 @@ defmodule Acmex do
   """
   @spec revoke_certificate(String.t(), integer()) :: certificate_revocation_reply()
   def revoke_certificate(certificate, reason_code \\ 0) do
-    GenServer.call(Client, {:revoke_certificate, certificate, reason_code})
+    GenServer.call(Client, {:revoke_certificate, certificate, reason_code}, genserver_timeout())
   end
 
   @spec child_spec(list()) :: Supervisor.child_spec()
@@ -240,4 +245,6 @@ defmodule Acmex do
       start: {__MODULE__, :start_link, args}
     }
   end
+
+  defp genserver_timeout, do: Application.get_env(:acmex, :genserver_timeout, 5_000)
 end

--- a/lib/acmex.ex
+++ b/lib/acmex.ex
@@ -62,6 +62,7 @@ defmodule Acmex do
 
     - contact: A list of URLs that the ACME can use to contact the client for issues related to this account.
     - tos: Terms Of Service Agreed indicates the client's agreement with the terms of service.
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -69,7 +70,7 @@ defmodule Acmex do
       {:ok, %Account{...}}
 
   """
-  @spec new_account([String.t()], boolean()) :: account_reply()
+  @spec new_account([String.t()], boolean(), integer()) :: account_reply()
   def new_account(contact, tos, timeout \\ 5_000),
     do: GenServer.call(Client, {:new_account, contact, tos}, timeout)
 
@@ -78,13 +79,16 @@ defmodule Acmex do
 
   An account will only be returned if the current private key has been used to create a new account.
 
+  ## Parameters
+    - timeout: Async process timeout in miliseconds. Default: 5_000
+
   ## Examples
 
       iex> Acmex.get_account()
       {:ok, %Account{...}}
 
   """
-  @spec get_account() :: account_reply()
+  @spec get_account(integer()) :: account_reply()
   def get_account(timeout \\ 5_000), do: GenServer.call(Client, :get_account, timeout)
 
   @doc """
@@ -92,6 +96,7 @@ defmodule Acmex do
 
   ## Parameters
     - identifiers: A list of domains.
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -99,7 +104,7 @@ defmodule Acmex do
       {:ok, %Order{...}}
 
   """
-  @spec new_order([String.t()]) :: order_reply()
+  @spec new_order([String.t()], integer()) :: order_reply()
   def new_order(identifiers, timeout \\ 5_000),
     do: GenServer.call(Client, {:new_order, identifiers}, timeout)
 
@@ -109,6 +114,7 @@ defmodule Acmex do
   ## Parameters
 
     - url: The url attribute of the order resource.
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -116,7 +122,7 @@ defmodule Acmex do
       {:ok, %Order{...}}
 
   """
-  @spec get_order(String.t()) :: order_reply()
+  @spec get_order(String.t(), integer()) :: order_reply()
   def get_order(url, timeout \\ 5_000), do: GenServer.call(Client, {:get_order, url}, timeout)
 
   @doc """
@@ -125,6 +131,7 @@ defmodule Acmex do
   ## Parameters
 
   - url: The url attribute of the challenge resource.
+  - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -132,7 +139,7 @@ defmodule Acmex do
       {:ok, %Challenge{...}}
 
   """
-  @spec get_challenge(String.t()) :: challenge_reply()
+  @spec get_challenge(String.t(), integer()) :: challenge_reply()
   def get_challenge(url, timeout \\ 5_000),
     do: GenServer.call(Client, {:get_challenge, url}, timeout)
 
@@ -142,6 +149,7 @@ defmodule Acmex do
   ## Parameters
 
     - challenge: The challenge resource.
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -162,7 +170,7 @@ defmodule Acmex do
          }}
 
   """
-  @spec get_challenge_response(Challenge.t()) :: {:ok, map()}
+  @spec get_challenge_response(Challenge.t(), integer()) :: {:ok, map()}
   def get_challenge_response(challenge, timeout \\ 5_000),
     do: GenServer.call(Client, {:get_challenge_response, challenge}, timeout)
 
@@ -172,6 +180,7 @@ defmodule Acmex do
   ## Parameters
 
     - challenge: The challenge resource.
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -179,7 +188,7 @@ defmodule Acmex do
       {:ok, %Challenge{...}}
 
   """
-  @spec validate_challenge(Challenge.t()) :: challenge_reply()
+  @spec validate_challenge(Challenge.t(), integer()) :: challenge_reply()
   def validate_challenge(challenge, timeout \\ 5_000),
     do: GenServer.call(Client, {:validate_challenge, challenge}, timeout)
 
@@ -189,6 +198,7 @@ defmodule Acmex do
   ## Parameters
 
     - order: The order resource with status "pending".
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -196,7 +206,7 @@ defmodule Acmex do
       {:ok, %Order{status: "processing"}}
 
   """
-  @spec finalize_order(Order.t(), String.t()) :: challenge_reply()
+  @spec finalize_order(Order.t(), String.t(), integer()) :: challenge_reply()
   def finalize_order(order, csr, timeout \\ 5_000),
     do: GenServer.call(Client, {:finalize_order, order, csr}, timeout)
 
@@ -208,6 +218,7 @@ defmodule Acmex do
   ## Parameters
 
     - order: The order resource with status "valid".
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -215,7 +226,7 @@ defmodule Acmex do
       {:ok, "-----BEGIN CERTIFICATE-----..."}
 
   """
-  @spec get_certificate(Order.t()) :: certificate_reply()
+  @spec get_certificate(Order.t(), integer()) :: certificate_reply()
   def get_certificate(order, timeout \\ 5_000),
     do: GenServer.call(Client, {:get_certificate, order}, timeout)
 
@@ -226,6 +237,7 @@ defmodule Acmex do
 
     - certificate: The certificate to be revoked.
     - reason: Optional revocation reason code.
+    - timeout: Async process timeout in miliseconds. Default: 5_000
 
   ## Examples
 
@@ -233,7 +245,7 @@ defmodule Acmex do
       :ok
 
   """
-  @spec revoke_certificate(String.t(), integer()) :: certificate_revocation_reply()
+  @spec revoke_certificate(String.t(), integer(), integer()) :: certificate_revocation_reply()
   def revoke_certificate(certificate, reason_code \\ 0, timeout \\ 5_000) do
     GenServer.call(Client, {:revoke_certificate, certificate, reason_code}, timeout)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Acmex.MixProject do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.1.3"
   @repo_url "https://github.com/sergioaugrod/acmex"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Acmex.MixProject do
   use Mix.Project
 
-  @version "0.1.3"
+  @version "0.2.0"
   @repo_url "https://github.com/sergioaugrod/acmex"
 
   def project do


### PR DESCRIPTION
# Motivation
Today we utilize this lib to communicate with Acme v2 Api in a big product, we identified that some requests connection would take more than 5000ms to complete (sometimes 1000ms more, others 5000ms more). However, the GenServer has a default timeout of 5000ms, thus, making our requests fail when it shouldn't.

# Solution
To fix this I've added a custom param to increase the GenServer timeout, with default value of 5_000. Like so:
```elixir
  def get_order(url, timeout \\ 5_000), do: GenServer.call(Client, {:get_order, url}, timeout)
```

# Comments

I hope this feature helps others who may have the same problem in the future =)

@sergioaugrod 
